### PR TITLE
Named cluster

### DIFF
--- a/odin_infrastructure/odin_api_stack.py
+++ b/odin_infrastructure/odin_api_stack.py
@@ -1,5 +1,6 @@
 from aws_cdk import Stack, aws_route53
 from aws_cdk import aws_ec2 as ec2
+from aws_cdk import aws_ecs as ecs
 from constructs import Construct
 
 from .admin_host import AdminInstance
@@ -56,7 +57,10 @@ class OdinAPIStack(Stack):
         )
         mongo: ec2.IInstance = MongoInstance(self, "OdinMongo", vpc)
         admin: ec2.IInstance = AdminInstance(self, "OdinAdmin", vpc)
-        OdinService(self, "OdinAPIFargateService", vpc, mongo)
+        cluster: ecs.ICluster = ecs.Cluster(
+            self, "OdinCluster", vpc=vpc, cluster_name="OdinApiCluster"
+        )
+        OdinService(self, "OdinAPIFargateService", mongo, cluster)
 
         aws_route53.ARecord(
             self,

--- a/odin_infrastructure/odin_cluster.py
+++ b/odin_infrastructure/odin_cluster.py
@@ -19,7 +19,11 @@ from .config import ODIN_CERTIFICATE_ARN
 
 class OdinService(aws_ecs_patterns.ApplicationLoadBalancedFargateService):
     def __init__(
-        self, scope: Stack, id: str, vpc: aws_ec2.IVpc, mongo: aws_ec2.IInstance
+        self,
+        scope: Stack,
+        id: str,
+        mongo: aws_ec2.IInstance,
+        cluster: aws_ecs.ICluster,
     ):
         log_group = aws_logs.LogGroup(
             scope,
@@ -113,6 +117,7 @@ class OdinService(aws_ecs_patterns.ApplicationLoadBalancedFargateService):
             ),
             cpu=2048,
             service_name="OdinFargateService",
+            cluster=cluster,
             desired_count=1,
             task_definition=odinapi_task,
             memory_limit_mib=4096,
@@ -121,7 +126,6 @@ class OdinService(aws_ecs_patterns.ApplicationLoadBalancedFargateService):
             domain_name="odin-smr.org",
             domain_zone=hosted_zone,
             certificate=cert,
-            vpc=vpc,
             idle_timeout=Duration.seconds(360),
             redirect_http=True,
         )

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,11 @@
 [tox]
-envlist = py310,lint,mypy
+envlist = py310
 
 [testenv]
 deps =
     -r requirements-dev.txt
 commands =
     pytest {posargs}
-
-[testenv:lint]
-commands =
     black --check .
-
-[testenv:mypy]
-commands =
     mypy .
+


### PR DESCRIPTION
Include a named cluster, instead of a automatic creaded one. Simplify tox.ini file for faster test execution.